### PR TITLE
[#104]feat: add_zylo_docs 에서 zylo_docs로 변경

### DIFF
--- a/zylo_docs/__init__.py
+++ b/zylo_docs/__init__.py
@@ -1,1 +1,1 @@
-from .integration import add_zylo_docs
+from .integration import zylo_docs

--- a/zylo_docs/integration.py
+++ b/zylo_docs/integration.py
@@ -16,7 +16,7 @@ def set_initial_openapi_spec(app: FastAPI):
     app.state.openapi_service.set_current_spec(openapi_json)
     print(f"http://{HOST}:{PORT}/zylo-docs")
 
-def add_zylo_docs(app: FastAPI):
+def zylo_docs(app: FastAPI):
     if not hasattr(app.state, 'openapi_service'):
         app.state.openapi_service = OpenApiService()
         
@@ -31,4 +31,3 @@ def add_zylo_docs(app: FastAPI):
         return FileResponse(os.path.join(os.path.dirname(__file__), "static", "index.html"))
 
     set_initial_openapi_spec(app)
-#


### PR DESCRIPTION
As-is
Currently, the function from the zylo-docs library is used as follows:

from zylo_docs.integration import add_zylo_docs
```
app = FastAPI()
add_zylo_docs(app)
```
To-be
Rename the function to zylo_docs so it can be used like this:
```
from zylo_docs.integration import zylo_docs

app = FastAPI()
zylo_docs(app)
```
