### PR TITLE
#130]feat: /base/spec/{spec_id} api 개발

### DIFF
--- a/zylo_docs/config.py
+++ b/zylo_docs/config.py
@@ -1,2 +1,2 @@
-EXTERNAL_API_BASE = "https://api.zylosystems.com/v1"
-# EXTERNAL_API_BASE = "http://0.0.0.0:8001/v1"
+# EXTERNAL_API_BASE = "https://api.zylosystems.com/v1"
+EXTERNAL_API_BASE = "http://0.0.0.0:8001/v1"

--- a/zylo_docs/routers/proxy_route.py
+++ b/zylo_docs/routers/proxy_route.py
@@ -185,6 +185,20 @@ async def get_spec(credentials: HTTPAuthorizationCredentials = Depends(security)
         media_type=resp.headers.get("content-type")
     )
 
+@router.get("/base/spec/{spec_id}", include_in_schema=False)
+async def get_specs_me_by_id(spec_id: str, credentials: HTTPAuthorizationCredentials = Depends(security)):
+    access_token = credentials.credentials
+    async with httpx.AsyncClient() as client:
+        try:
+            spec_content = await get_spec_content_by_id(spec_id, client, access_token, source="original")
+            return spec_content
+        except httpx.HTTPStatusError as exc:
+            return Response(
+                content=exc.response.content,
+                status_code=exc.response.status_code,
+                media_type=exc.response.headers.get("content-type")
+            )
+
 @router.patch("/testcases", include_in_schema=False)
 async def create_test_case(request: Request, body: TestCasePatchBody, credentials: HTTPAuthorizationCredentials = Depends(security)):
     access_token = credentials.credentials

--- a/zylo_docs/services/hub_server_service.py
+++ b/zylo_docs/services/hub_server_service.py
@@ -1,9 +1,9 @@
 import httpx
 from fastapi import HTTPException
 from zylo_docs.config import EXTERNAL_API_BASE
-async def get_spec_content_by_id(spec_id: str, client: httpx.AsyncClient, access_token: str) -> dict:
+async def get_spec_content_by_id(spec_id: str, client: httpx.AsyncClient, access_token: str, source: str = "tuned") -> dict:
     try:
-        resp = await client.get(f"{EXTERNAL_API_BASE}/specs/{spec_id}", headers={"Authorization": f"Bearer {access_token}"})
+        resp = await client.get(f"{EXTERNAL_API_BASE}/specs/{spec_id}?source={source}", headers={"Authorization": f"Bearer {access_token}"})
         resp.raise_for_status()
         response_data = resp.json()
         spec_content = response_data.get("data", {}).get("spec_content")


### PR DESCRIPTION
As-is
no feature to display the base spec data of currently viewed spec

To-be
implement feature to display the base spec data of currently viewed spec

created api
```
@router.get("/base/spec/{spec_id}", include_in_schema=False)
async def get_specs_me_by_id(spec_id: str, credentials: HTTPAuthorizationCredentials = Depends(security)):
```
